### PR TITLE
#56 - Remove magnet pattern in obj()

### DIFF
--- a/forProductN.sc
+++ b/forProductN.sc
@@ -22,7 +22,7 @@ def generateProductToJson = {
     out ++= (0 until i).map(j => s"a$j").mkString(", ")
     out ++= ") = f(target)\n"
     out ++= "obj("
-    out ++= (0 until i).map(j => s"(nameA$j, a$j)").mkString(", ")
+    out ++= (0 until i).map(j => s"(nameA$j ~> a$j)").mkString(", ")
     out ++= ")\n}\n"
   }
 

--- a/json4s-compat/src/nrktkt/ninny/compat/Json4sCompat.scala
+++ b/json4s-compat/src/nrktkt/ninny/compat/Json4sCompat.scala
@@ -13,7 +13,7 @@ object Json4sCompat {
     def ~[B: ToJson](newPair: (String, B))(implicit
         aToJson: ToJson[A]
     ): JsonObject =
-      obj(pair._1 -> pair._2, newPair._1 -> newPair._2)
+      obj(pair._1 ~> pair._2, newPair._1 ~> newPair._2)
   }
 
   implicit class JsonObjectSyntax(json: JsonObject) {

--- a/json4s-compat/test/src/nrktkt/ninny/compat/Json4sCompatSpec.scala
+++ b/json4s-compat/test/src/nrktkt/ninny/compat/Json4sCompatSpec.scala
@@ -1,6 +1,7 @@
 package nrktkt.ninny.compat
 
 import nrktkt.ninny.ast._
+import nrktkt.ninny._
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should
@@ -31,13 +32,13 @@ class Json4sCompatSpec
       )
 
       val ninny = nrktkt.ninny.obj(
-        "long"        -> JsonDouble(1),
-        "bigInt"      -> BigDecimal(1),
-        "exactNumber" -> BigDecimal("1.23"),
-        "bool"        -> true,
-        "string"      -> "value",
-        "null"        -> JsonNull,
-        "array"       -> Seq(JsonNull)
+        "long"        ~> JsonDouble(1),
+        "bigInt"      ~> BigDecimal(1),
+        "exactNumber" ~> BigDecimal("1.23"),
+        "bool"        ~> true,
+        "string"      ~> "value",
+        "null"        ~> JsonNull,
+        "array"       ~> Seq(JsonNull)
       )
 
       Json4sCompat.toNinnyJson(json4s).value shouldEqual ninny
@@ -45,13 +46,13 @@ class Json4sCompatSpec
 
     "Conversion from ninny to json4s" should "convert all types" in {
       val ninny = nrktkt.ninny.obj(
-        "long"        -> JsonDouble(1),
-        "bigInt"      -> BigDecimal(1),
-        "exactNumber" -> BigDecimal("1.23"),
-        "bool"        -> true,
-        "string"      -> "value",
-        "null"        -> JsonNull,
-        "array"       -> Seq(JsonNull)
+        "long"        ~> JsonDouble(1),
+        "bigInt"      ~> BigDecimal(1),
+        "exactNumber" ~> BigDecimal("1.23"),
+        "bool"        ~> true,
+        "string"      ~> "value",
+        "null"        ~> JsonNull,
+        "array"       ~> Seq(JsonNull)
       )
 
       val json4s = JObject(

--- a/ninny/src/nrktkt/ninny/package.scala
+++ b/ninny/src/nrktkt/ninny/package.scala
@@ -1,8 +1,7 @@
 package nrktkt
 
 import nrktkt.ninny.ast._
-import nrktkt.ninny.magnetic.{JsonMagnet, SomeJsonMagnet}
-
+import nrktkt.ninny.magnetic.{SomeJsonMagnet}
 import scala.language.dynamics
 import scala.util.Try
 
@@ -65,9 +64,9 @@ package object ninny {
   }
 
   implicit class ArrowSyntax(val s: String) extends AnyVal {
-    def -->[A: ToJson](a: A) = s -> JsonMagnet(a)
+    def -->[A: ToJson](a: A): (String, Option[JsonValue]) = s -> a.toJson
     // I couldn't decide on syntax, so I'll throw both out there
-    def ~>[A: ToJson](a: A) = s -> JsonMagnet(a)
+    def ~>[A: ToJson](a: A): (String, Option[JsonValue]) = s -> a.toJson
   }
 
   type ToJson[A]           = ToJsonValue[A, JsonValue]
@@ -75,13 +74,13 @@ package object ninny {
   type ToSomeJson[A]       = ToSomeJsonValue[A, JsonValue]
   type ToSomeJsonObject[A] = ToSomeJsonValue[A, JsonObject]
 
-  // @deprecated(
-  //  message =
-  //    "Use nrktkt.ninny.magnetic.obj instead, this may be replaced with a magnet-free signature in the future",
-  //  since = ""
-  // )
-  def obj(nameValues: (String, JsonMagnet)*): JsonObject =
-    magnetic.obj(nameValues: _*)
+  // Import nrktkt.ninny.magnetic.obj if the magnet pattern is preferrable
+  def obj(fields: (String, Option[JsonValue])*): JsonObject =
+    JsonObject(
+      fields.collect { case (name, Some(json)) =>
+        name -> json
+      }.toMap
+    )
 
   // @deprecated(
   //  message =

--- a/ninny/test/src-2/nrktkt/ninny/JsonSpec.scala
+++ b/ninny/test/src-2/nrktkt/ninny/JsonSpec.scala
@@ -14,10 +14,10 @@ import java.util.UUID
 import scala.util.Random
 import scala.collection.compat.immutable.ArraySeq
 import java.util.Base64
-import nrktkt.ninny.magnetic.JsonMagnet
-import nrktkt.ninny.magnetic.SomeJsonMagnet
 import nrktkt.ninny.ToAndFromJson
 import scala.util.Failure
+import nrktkt.ninny.magnetic.JsonMagnet
+import nrktkt.ninny.magnetic.SomeJsonMagnet
 
 class JsonSpec
     extends AnyFlatSpec
@@ -27,13 +27,13 @@ class JsonSpec
 
   it should "work" in {
     val sampleValues = obj(
-      "string" -> """¯\_(ツ)_/¯""",
-      "number" -> 1.79e308,
-      "bool"   -> true,
-      "false"  -> false,
-      "null"   -> JsonNull,
-      "unit"   -> ((): Unit),
-      "some"   -> "str"
+      "string" ~> """¯\_(ツ)_/¯""",
+      "number" ~> 1.79e308,
+      "bool"   ~> true,
+      "false"  ~> false,
+      "null"   ~> JsonNull,
+      "unit"   ~> ((): Unit),
+      "some"   ~> "str"
     )
 
     val sampleArray =
@@ -42,8 +42,8 @@ class JsonSpec
     val sampleObject =
       JsonObject(
         sampleValues.values ++ obj(
-          "object" -> sampleValues,
-          "array"  -> sampleArray
+          "object" ~> sampleValues,
+          "array"  ~> sampleArray
         ).values
       )
 
@@ -92,13 +92,13 @@ class JsonSpec
   }
 
   val sampleValuesAst = obj(
-    "string" -> """¯\_(ツ)_/¯""",
-    "number" -> 1.79e308,
-    "bool"   -> true,
-    "false"  -> false,
-    "null"   -> JsonNull,
-    "unit"   -> ((): Unit),
-    "some"   -> Some("str")
+    "string" ~> """¯\_(ツ)_/¯""",
+    "number" ~> 1.79e308,
+    "bool"   ~> true,
+    "false"  ~> false,
+    "null"   ~> JsonNull,
+    "unit"   ~> ((): Unit),
+    "some"   ~> Some("str")
   )
 
   val sampleValuesObj = SampleValues(
@@ -182,40 +182,40 @@ class JsonSpec
       |""".stripMargin
 
   val exampleObjectAst = obj(
-    "Image" -> obj(
-      "Width"  -> 800,
-      "Height" -> 600,
-      "Title"  -> "View from 15th Floor",
-      "Thumbnail" -> obj(
-        "Url"    -> "http://www.example.com/image/481989943",
-        "Height" -> 125,
-        "Width"  -> 100
+    "Image" ~> obj(
+      "Width"  ~> 800,
+      "Height" ~> 600,
+      "Title"  ~> "View from 15th Floor",
+      "Thumbnail" ~> obj(
+        "Url"    ~> "http://www.example.com/image/481989943",
+        "Height" ~> 125,
+        "Width"  ~> 100
       ),
-      "Animated" -> false,
-      "IDs"      -> arr(116, 943, 234, 38793)
+      "Animated" ~> false,
+      "IDs"      ~> arr(116, 943, 234, 38793)
     )
   )
 
   val exampleArrayAst = arr(
     obj(
-      "precision" -> "zip",
-      "Latitude"  -> 37.7668,
-      "Longitude" -> -122.3959,
-      "Address"   -> "",
-      "City"      -> "SAN FRANCISCO",
-      "State"     -> "CA",
-      "Zip"       -> "94107",
-      "Country"   -> "US"
+      "precision" ~> "zip",
+      "Latitude"  ~> 37.7668,
+      "Longitude" ~> -122.3959,
+      "Address"   ~> "",
+      "City"      ~> "SAN FRANCISCO",
+      "State"     ~> "CA",
+      "Zip"       ~> "94107",
+      "Country"   ~> "US"
     ),
     obj(
-      "precision" -> "zip",
-      "Latitude"  -> 37.371991,
-      "Longitude" -> -122.026020,
-      "Address"   -> "",
-      "City"      -> "SUNNYVALE",
-      "State"     -> "CA",
-      "Zip"       -> "94085",
-      "Country"   -> "US"
+      "precision" ~> "zip",
+      "Latitude"  ~> 37.371991,
+      "Longitude" ~> -122.026020,
+      "Address"   ~> "",
+      "City"      ~> "SUNNYVALE",
+      "State"     ~> "CA",
+      "Zip"       ~> "94085",
+      "Country"   ~> "US"
     )
   )
 
@@ -244,13 +244,13 @@ class JsonSpec
 
     implicit val toJson: ToSomeJson[Image] = a =>
       obj(
-        "Width"     -> a.Width,
-        "Height"    -> a.Height,
-        "Title"     -> a.Title,
-        "Thumbnail" -> a.Thumbnail,
-        "Url"       -> a.Url,
-        "Animated"  -> a.Animated,
-        "IDs"       -> (if (a.IDs.isEmpty) None else a.IDs)
+        "Width"     ~> a.Width,
+        "Height"    ~> a.Height,
+        "Title"     ~> a.Title,
+        "Thumbnail" ~> a.Thumbnail,
+        "Url"       ~> a.Url,
+        "Animated"  ~> a.Animated,
+        "IDs"       ~> (if (a.IDs.isEmpty) None else Some(a.IDs))
       )
   }
 
@@ -280,14 +280,14 @@ class JsonSpec
 
     implicit val toJson: ToSomeJson[Address] = a =>
       obj(
-        "precision" -> a.precision,
-        "Latitude"  -> a.Latitude,
-        "Longitude" -> a.Longitude,
-        "Address"   -> a.Address,
-        "City"      -> a.City,
-        "State"     -> a.State,
-        "Zip"       -> a.Zip,
-        "Country"   -> a.Country
+        "precision" ~> a.precision,
+        "Latitude"  ~> a.Latitude,
+        "Longitude" ~> a.Longitude,
+        "Address"   ~> a.Address,
+        "City"      ~> a.City,
+        "State"     ~> a.State,
+        "Zip"       ~> a.Zip,
+        "Country"   ~> a.Country
       )
   }
 
@@ -461,7 +461,7 @@ class JsonSpec
   }
 
   "JsonObjects" should "rename fields" in {
-    val json    = obj("foo" -> "bar")
+    val json    = obj("foo" ~> "bar")
     val renamed = json.renameField("foo", "baz")
     (renamed / "baz").value shouldEqual JsonString("bar")
     (renamed / "foo") shouldEqual None
@@ -566,7 +566,7 @@ class JsonSpec
 
   "magnet free syntax" should "work" in {
     val o = obj(
-      "foo" -> 5,
+      "foo" ~> 5,
       "bar" --> 7,
       "baz" ~> 11
     )
@@ -640,7 +640,7 @@ class JsonSpec
     val example = Example("bar", 1)
     val js      = example.toSomeJson
     val fromJs  = js.to[Example].success.value
-    js shouldEqual obj("baz" -> "bar", "bop" -> 1)
+    js shouldEqual obj("baz" ~> "bar", "bop" ~> 1)
     fromJs shouldEqual example
   }
   {
@@ -652,8 +652,8 @@ class JsonSpec
         ToAndFromJson.auto[Example]
       }
 
-      obj("qix" -> 1).to[Example].success.value shouldEqual Example(1)
-      obj("qix" -> 1, "foo" -> "baz")
+      obj("qix" ~> 1).to[Example].success.value shouldEqual Example(1)
+      obj("qix" ~> 1, "foo" ~> "baz")
         .to[Example]
         .success
         .value shouldEqual Example(1, "baz")
@@ -662,8 +662,8 @@ class JsonSpec
     it should "ignore defaults if the default import isn't available" in {
       import Auto._
 
-      obj("qix" -> 1).to[Example] shouldBe a[Failure[_]]
-      obj("qix" -> 1, "foo" -> "baz")
+      obj("qix" ~> 1).to[Example] shouldBe a[Failure[_]]
+      obj("qix" ~> 1, "foo" ~> "baz")
         .to[Example]
         .success
         .value shouldEqual Example(1, "baz")

--- a/ninny/test/src-2/nrktkt/ninny/example/Example.scala
+++ b/ninny/test/src-2/nrktkt/ninny/example/Example.scala
@@ -62,7 +62,7 @@ object Example extends App {
   println()
 
   val profileUpdateJson =
-    obj("email" -> JsonNull, "bio" -> "Just a zombie looking for his Jane")
+    obj("email" ~> JsonNull, "bio" ~> "Just a zombie looking for his Jane")
 
   val profileUpdate = profileUpdateJson.to[UpdateProfile].get
   println("Parsed profile update")

--- a/ninny/test/src-2/nrktkt/ninny/example/Userguide.scala
+++ b/ninny/test/src-2/nrktkt/ninny/example/Userguide.scala
@@ -75,14 +75,14 @@ json.age.to[Option[String]] // Success(None)
 ////////////////////////
 
 val json1 = obj(
-  "firstName" -> "John",
-  "lastName"  -> "Doe",
-  "address" -> obj(
-    "street" -> "710 Ashbury St",
-    "zip"    -> "94117"
+  "firstName" ~> "John",
+  "lastName"  ~> "Doe",
+  "address" ~> obj(
+    "street" ~> "710 Ashbury St",
+    "zip"    ~> "94117"
   ),
-  "kids" -> arr("Jr", "Jane"),
-  "age"  -> None
+  "kids" ~> arr("Jr", "Jane"),
+  "age"  ~> None
 )
 
 Json.render(json1) // {"lastName":"Doe","firstName":"John","address":{"street":"710 Ashbury St","zip":"94117"},"kids":["Jr","Jane"]}
@@ -90,9 +90,9 @@ Json.render(json1) // {"lastName":"Doe","firstName":"John","address":{"street":"
 ////////////////////////////////////////////
 
 val deep = obj(
-  "one" -> obj(
-    "two" -> obj(
-      "three" -> "value!"
+  "one" ~> obj(
+    "two" ~> obj(
+      "three" ~> "value!"
     )
   )
 )
@@ -119,8 +119,8 @@ case class Address(street: String, zip: String)
   */
 implicit val addressToJson: ToSomeJson[Address] = a =>
   obj(
-    "street" -> a.street,
-    "zip"    -> a.zip
+    "street" ~> a.street,
+    "zip"    ~> a.zip
   )
 
 implicit val addressFromJson: FromJson[Address] = {
@@ -134,11 +134,11 @@ implicit val addressFromJson: FromJson[Address] = {
 
 implicit val personToJson: ToSomeJson[Person] = p =>
   obj(
-    "firstName" -> p.firstName,
-    "lastName"  -> p.lastName,
-    "address"   -> p.address,
-    "kids"      -> p.kids,
-    "age"       -> p.age
+    "firstName" ~> p.firstName,
+    "lastName"  ~> p.lastName,
+    "address"   ~> p.address,
+    "kids"      ~> p.kids,
+    "age"       ~> p.age
   )
 
 implicit val personFromJson = FromJson.fromSome[Person](json =>

--- a/ninny/test/src-2/nrktkt/ninny/userguide/DomainTo.scala
+++ b/ninny/test/src-2/nrktkt/ninny/userguide/DomainTo.scala
@@ -25,19 +25,19 @@ object Address {
    */
   implicit val toJson: ToSomeJson[Address] = a =>
     obj(
-      "street" -> a.street,
-      "zip"    -> a.zip
+      "street" ~> a.street,
+      "zip"    ~> a.zip
     )
 }
 
 object Person {
   implicit val toJson: ToSomeJson[Person] = p =>
     obj(
-      "firstName" -> p.firstName,
-      "lastName"  -> p.lastName,
-      "address"   -> p.address,
-      "kids"      -> p.kids,
-      "age"       -> p.age
+      "firstName" ~> p.firstName,
+      "lastName"  ~> p.lastName,
+      "address"   ~> p.address,
+      "kids"      ~> p.kids,
+      "age"       ~> p.age
     )
 }
 

--- a/ninny/test/src-2/nrktkt/ninny/userguide/Updating.scala
+++ b/ninny/test/src-2/nrktkt/ninny/userguide/Updating.scala
@@ -6,9 +6,9 @@ object Updating {
 import nrktkt.ninny._
 
 val json = obj(
-  "one" -> obj(
-    "two" -> obj(
-      "three" -> "value!"
+  "one" ~> obj(
+    "two" ~> obj(
+      "three" ~> "value!"
     )
   )
 )

--- a/ninny/test/src-2/nrktkt/ninny/userguide/Writing.scala
+++ b/ninny/test/src-2/nrktkt/ninny/userguide/Writing.scala
@@ -24,14 +24,14 @@ None.toSomeJson
 //---
 
 val json = obj(
-  "firstName" -> "John",
-  "lastName"  -> "Doe",
-  "address" -> obj(
-    "street" -> "710 Ashbury St",
-    "zip"    -> "94117"
+  "firstName" ~> "John",
+  "lastName"  ~> "Doe",
+  "address" ~> obj(
+    "street" ~> "710 Ashbury St",
+    "zip"    ~> "94117"
   ),
-  "kids" -> arr("Jr", "Jane"),
-  "age"  -> None
+  "kids" ~> arr("Jr", "Jane"),
+  "age"  ~> None
 )
 
 Json.render(json) 

--- a/ninny/test/src/nrktkt/ninny/UpdateSpec.scala
+++ b/ninny/test/src/nrktkt/ninny/UpdateSpec.scala
@@ -1,9 +1,9 @@
-package io.github.kag0.ninny
+package nrktkt.ninny
 
 import org.scalatest._
 import org.scalatest.flatspec._
 import org.scalatest.matchers._
-import io.github.kag0.ninny.ast._
+import nrktkt.ninny.ast._
 
 class UpdateSpec
     extends AnyFlatSpec
@@ -12,19 +12,19 @@ class UpdateSpec
     with OptionValues {
 
   val sampleObject = obj(
-    "a" -> arr(
+    "a" ~> arr(
       obj(
-        "b" -> obj(
-          "c" -> arr(
+        "b" ~> obj(
+          "c" ~> arr(
             0,
             1,
             2,
-            obj("d" -> "foo")
+            obj("d" ~> "foo")
           )
         )
       )
     ),
-    "z" -> "baz"
+    "z" ~> "baz"
   )
 
   "Updating nested objects" should "work with dynamic syntax" in {

--- a/ninny/test/src/nrktkt/ninny/ValueMethodsSpec.scala
+++ b/ninny/test/src/nrktkt/ninny/ValueMethodsSpec.scala
@@ -12,8 +12,8 @@ class ValueMethodsSpec
     with TryValues {
 
   "JsonObject deep merge" should "merge object fields" in {
-    val left   = obj("inner" -> obj("field" -> "value"))
-    val right  = obj("inner" -> obj("field2" -> "value2"))
+    val left   = obj("inner" ~> obj("field" ~> "value"))
+    val right  = obj("inner" ~> obj("field2" ~> "value2"))
     val merged = left +++ right
     merged.inner.field.to[String].success.value shouldEqual "value"
     merged.inner.field2.to[String].success.value shouldEqual "value2"
@@ -22,17 +22,17 @@ class ValueMethodsSpec
   it should "overwrite with the new value" in {
     val left =
       obj(
-        "inner" -> obj(
-          "field"  -> "value",
-          "field2" -> obj("x" -> "y"),
-          "field3" -> 2
+        "inner" ~> obj(
+          "field"  ~> "value",
+          "field2" ~> obj("x" ~> "y"),
+          "field3" ~> 2
         )
       )
     val right = obj(
-      "inner" -> obj(
-        "field"  -> "value2",
-        "field2" -> 1,
-        "field3" -> obj("x" -> "y")
+      "inner" ~> obj(
+        "field"  ~> "value2",
+        "field2" ~> 1,
+        "field3" ~> obj("x" ~> "y")
       )
     )
     val merged = left +++ right

--- a/play-compat/test/src/nrktkt/ninny/compat/PlayCompatSpec.scala
+++ b/play-compat/test/src/nrktkt/ninny/compat/PlayCompatSpec.scala
@@ -27,7 +27,7 @@ class PlayCompatSpec
 
   val ex1 = Example1("baz", Seq(1, 2, 3))
   val ex2 = Example2("baz", Seq(1, 2, 3))
-  val ex1json = obj("foo" -> "baz", "bar" -> Seq(1, 2, 3))
+  val ex1json = obj("foo" ~> "baz", "bar" ~> Seq(1, 2, 3))
   val ex2json = PlayJson.obj("foo" -> "baz", "bar" -> PlayJson.arr(1, 2, 3))
 
   "Play typeclasses" should "write ninny json" in {

--- a/script-kit/test/src/nrktkt/ninny/script-kit/SkSyntaxSpec.scala
+++ b/script-kit/test/src/nrktkt/ninny/script-kit/SkSyntaxSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.OptionValues
 
 class SkSyntaxSpec extends AnyFlatSpec with should.Matchers {
 
-  val o = obj("obj" -> obj("present" -> 5))
+  val o = obj("obj" ~> obj("present" ~> 5))
 
   "lookup finalization syntax" should "return present values" in {
     o.obj.present.! shouldEqual JsonNumber(5)

--- a/ubjson/README.md
+++ b/ubjson/README.md
@@ -2,7 +2,7 @@
 
 This module supports converting the AST to and from Universal Binary JSON.
 
-Usage is idential to standard JSON, with the exception that `nrktkt.ninny.Json` is replaced with `nrktkt.ninny.binary.UbJson`.
+Usage is identical to standard JSON, with the exception that `nrktkt.ninny.Json` is replaced with `nrktkt.ninny.binary.UbJson`.
 
 For example
 

--- a/ubjson/test/src/nrktkt/ninny/binary/UbJsonSpec.scala
+++ b/ubjson/test/src/nrktkt/ninny/binary/UbJsonSpec.scala
@@ -307,11 +307,11 @@ class UbJsonSpec extends AnyFlatSpec with should.Matchers with TryValues {
 
     val parsed = UbJson.parse(binary).success.value
     parsed shouldEqual obj(
-      "null"   -> JsonNull,
-      "string" -> "foo",
-      "bool"   -> true,
-      "num"    -> float,
-      "char"   -> "!"
+      "null"   ~> JsonNull,
+      "string" ~> "foo",
+      "bool"   ~> true,
+      "num"    ~> float,
+      "char"   ~> "!"
     )
   }
 
@@ -325,11 +325,11 @@ class UbJsonSpec extends AnyFlatSpec with should.Matchers with TryValues {
 
     val parsed = UbJson.parse(binary).success.value
     parsed shouldEqual obj(
-      "null"   -> JsonNull,
-      "string" -> "foo",
-      "bool"   -> true,
-      "num"    -> float,
-      "char"   -> "!"
+      "null"   ~> JsonNull,
+      "string" ~> "foo",
+      "bool"   ~> true,
+      "num"    ~> float,
+      "char"   ~> "!"
     )
   }
 
@@ -343,21 +343,21 @@ class UbJsonSpec extends AnyFlatSpec with should.Matchers with TryValues {
 
     val parsed = UbJson.parse(binary).success.value
     parsed shouldEqual obj(
-      "a" -> a,
-      "b" -> b,
-      "c" -> c,
-      "d" -> d
+      "a" ~> a,
+      "b" ~> b,
+      "c" ~> c,
+      "d" ~> d
     )
   }
 
   it should "render objects" in {
     UbJson.render(
       obj(
-        "null"   -> JsonNull,
-        "string" -> "foo",
-        "bool"   -> true,
-        "num"    -> float,
-        "char"   -> "!"
+        "null"   ~> JsonNull,
+        "string" ~> "foo",
+        "bool"   ~> true,
+        "num"    ~> float,
+        "char"   ~> "!"
       )
     ) shouldEqual ArraySeq[Byte]('{') :++
       stringField :++
@@ -431,20 +431,20 @@ class UbJsonSpec extends AnyFlatSpec with should.Matchers with TryValues {
 
   "UBJSON" should "satisfy identity" in {
     val o = obj(
-      "foo"    -> "bar",
-      "num"    -> 5,
-      "bool"   -> true,
-      "bignum" -> BigDecimal("12.3e7"),
-      "float"  -> 12.3,
-      "null"   -> JsonNull,
-      "bin"    -> JsonBlob(ArraySeq[Byte](1, 2, 3)),
-      "arr" -> arr(
+      "foo"    ~> "bar",
+      "num"    ~> 5,
+      "bool"   ~> true,
+      "bignum" ~> BigDecimal("12.3e7"),
+      "float"  ~> 12.3,
+      "null"   ~> JsonNull,
+      "bin"    ~> JsonBlob(ArraySeq[Byte](1, 2, 3)),
+      "arr" ~> arr(
         1,
         true,
         12.3,
         obj(
-          "nested" -> "!",
-          "again!" -> arr(1, 2, 3)
+          "nested" ~> "!",
+          "again!" ~> arr(1, 2, 3)
         )
       )
     )


### PR DESCRIPTION
per #56 -- make `obj()` a non-magnetic impl. I bailed out trying to make `arr()` for now, but I do think it's possible but not elegant. 