### PR TITLE
Add implementation: `JsonObject#mapAllNames`

### DIFF
--- a/ninny/src/nrktkt/ninny/ast/package.scala
+++ b/ninny/src/nrktkt/ninny/ast/package.scala
@@ -42,6 +42,22 @@ package object ast {
       f(k) -> v
     })
 
+    def mapNamesR(f: String => String): JsonObject = {
+      val renamedFields = values.map {
+        case (name: String, value: JsonValue) =>
+          val updatedName = f(name)
+
+          val updatedValue = value match {
+            case obj: JsonObject => obj.mapNamesR(f)
+            case _               => value
+          }
+
+          updatedName -> updatedValue
+      }
+
+      JsonObject(renamedFields)
+    }
+
     def +[A: ToJson](entry: (String, A)) =
       entry._2.toJson match {
         case Some(value) =>

--- a/ninny/src/nrktkt/ninny/ast/package.scala
+++ b/ninny/src/nrktkt/ninny/ast/package.scala
@@ -42,13 +42,13 @@ package object ast {
       f(k) -> v
     })
 
-    def mapNamesR(f: String => String): JsonObject = {
+    def mapAllNames(f: String => String): JsonObject = {
       val renamedFields = values.map {
         case (name: String, value: JsonValue) =>
           val updatedName = f(name)
 
           val updatedValue = value match {
-            case obj: JsonObject => obj.mapNamesR(f)
+            case obj: JsonObject => obj.mapAllNames(f)
             case _               => value
           }
 


### PR DESCRIPTION
This is a recursive version of `JsonObject#mapNames`.  The prototypical use case for this is to recursively camel-case key names before converting to a Scala domain type.

Test cases have been added that mirror those of `JsonObject#mapNames`.

Coded in partnership with @HaydenSikh.